### PR TITLE
fix(Execute Shell Command): Fix exception return type inconsistency and print formatting (fixes #463)

### DIFF
--- a/Execute Shell Command/execute_shell_command.py
+++ b/Execute Shell Command/execute_shell_command.py
@@ -8,11 +8,11 @@ def execute_shell_command(command):
         out, err = proc.communicate()
         return_code = proc.returncode
         if err:
-            print(str(err))
+            print(err.decode('utf8', errors='ignore'))
         return out, return_code
     except Exception as err:
-        print("Exception Occurred while executing module : %s", str(err))
-        return 105
+        print(f"Exception Occurred while executing module : {err}")
+        return b'', 105
 
 if __name__ == '__main__':
     command ='echo Deepak'

--- a/Execute Shell Command/execute_shell_command_test.py
+++ b/Execute Shell Command/execute_shell_command_test.py
@@ -7,6 +7,10 @@ class TestShellCommand(unittest.TestCase):
         result, status = shell.execute_shell_command('echo Khanna')
         self.assertEqual(result.decode('utf8').rstrip("\r\n"), 'Khanna')
 
+    def test_shell_command_non_zero_status(self):
+        result, status = shell.execute_shell_command('non_existent_command_12345')
+        self.assertNotEqual(status, 0)
+        self.assertIsInstance(result, bytes)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)
-


### PR DESCRIPTION
Fixes #463

### Changes Proposed
- **Execute Shell Command/execute_shell_command.py**: Fixed exception return value to `(b'', 105)` so tuple unpacking `result, status` works consistently without crashing with `TypeError`.
- **Execute Shell Command/execute_shell_command.py**: Fixed string formatting in print statement using f-string.
- **Execute Shell Command/execute_shell_command.py**: Decoded `err` bytes cleanly before output.
- **Execute Shell Command/execute_shell_command_test.py**: Added test case `test_shell_command_non_zero_status` for non-zero status / failing shell commands.